### PR TITLE
add support for directories in browser files and rem extra loop in browser copy files

### DIFF
--- a/DFIR-Script.ps1
+++ b/DFIR-Script.ps1
@@ -385,6 +385,10 @@ function Get-ChromiumFiles {
         'History'
     )
 
+    $dirsToCopy = @(
+        'IndexedDB'
+    )
+
     Get-ChildItem "C:\Users\$Username\AppData\Local\*\*\User Data\*\" | Where-Object { `
         (Test-Path "$_\History") -and `
         [char[]](Get-Content "$($_.FullName)\History" -Encoding byte -TotalCount 'SQLite format'.Length) -join ''
@@ -395,6 +399,23 @@ function Get-ChromiumFiles {
 
         $filesToCopy | ForEach-Object{
             $filesToCopy | Where-Object{ Test-Path "$srcpath\$_" } | ForEach-Object{ Copy-Item -Path "$srcpath\$_" -Destination "$destpath\$_" }
+        }
+
+        foreach ( $fname in $filesToCopy ) {
+            $srcfile = Join-Path $srcpath $fname
+            $destfile = Join-Path $destpath $fname
+            if ( Test-Path $srcfile ) {
+                Copy-Item -Path $srcfile -Destination $destfile -Force
+            }
+        }
+
+        foreach ( $reldir in $dirsToCopy ) {
+            $srcdir = Join-Path $srcpath $reldir
+            $destdir = Join-Path $destpath $reldir
+            if ( Test-Path $srcdir ) {
+                New-Item -Path $destdir -ItemType Directory -Force | Out-Null
+                Copy-Item -Path "$srcdir\*" -Destination $destdir -Recurse -Force
+            }
         }
     }
 }


### PR DESCRIPTION
Remove extra nested loop from Chrome-like browser copy files and add support for copying directory (enables ability to extract `localStorage` LevelDB files).

Tested on Windows 11 only although that Chromium path hasn't changed since Windows 10.